### PR TITLE
Add an icon to indicate that a card is in the QA column

### DIFF
--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -23,6 +23,10 @@ const getIcon = story => {
     return <i className={`fas fa-minus-circle ${styles.icon}`} />;
   }
 
+if (story.workflow_state_id == 500074438 || story.workflow_state_id == 500081148){
+return <i className={`fas fa-question-circle ${styles.icon}`} />;
+}
+
   return null;
 };
 


### PR DESCRIPTION
I _think_ that this should show a question mark in a circle when the state is QA - I collected the workflow state IDs from the Clubhouse API so that we had a way to check this.