### PR TITLE
Replace deprecated sequelize modal aliases

### DIFF
--- a/server/server/controllers/goals.js
+++ b/server/server/controllers/goals.js
@@ -25,7 +25,7 @@ const list = (req, res) =>
     .catch(error => res.status(400).send(error));
 
 const update = (req, res) =>
-  Goal.findById(req.params.goalId)
+  Goal.findByPk(req.params.goalId)
     .then(goal => {
       if (!goal) {
         return res.status(404).send({
@@ -48,7 +48,7 @@ const update = (req, res) =>
 
 const destroy = async (req, res) => {
   try {
-    const goal = await Goal.findById(req.params.goalId);
+    const goal = await Goal.findByPk(req.params.goalId);
 
     if (!goal) {
       return res.status(404).send({
@@ -83,7 +83,7 @@ const destroy = async (req, res) => {
 const updateOrders = async (req, res) => {
   try {
     const updates = Object.keys(req.body).map(async goalId => {
-      const goal = await Goal.findById(goalId);
+      const goal = await Goal.findByPk(goalId);
       return goal.update({
         order: req.body[goalId],
       });

--- a/server/server/controllers/stories.js
+++ b/server/server/controllers/stories.js
@@ -84,7 +84,7 @@ const create = (req, res) => {
       }),
     )
     .then(story =>
-      Goal.findById(req.body.goalId)
+      Goal.findByPk(req.body.goalId)
         .then(goal =>
           goal.update({
             cards: [...goal.cards, story.id],

--- a/server/server/controllers/teams.js
+++ b/server/server/controllers/teams.js
@@ -15,7 +15,7 @@ const list = (req, res) =>
     .catch(error => res.status(400).send(error));
 
 const update = (req, res) =>
-  Team.findById(req.params.teamId)
+  Team.findByPk(req.params.teamId)
     .then(team => {
       if (!team) {
         return res.status(404).send({

--- a/server/server/controllers/webhook.js
+++ b/server/server/controllers/webhook.js
@@ -15,7 +15,7 @@ const _isArchived = action =>
   !!action.changes.archived;
 
 const update = (req, res) =>
-  Goal.all().then(goals => {
+  Goal.findAll().then(goals => {
     res.status(200).send();
 
     const goalsJSON = goals.map(goal => goal.toJSON());

--- a/server/server/scripts/update-dataset.js
+++ b/server/server/scripts/update-dataset.js
@@ -57,7 +57,7 @@ const formatDataForDataset = (goals, stories) =>
   });
 
 const updateDataset = teamId =>
-  Team.findById(teamId, {
+  Team.findByPk(teamId, {
     include: [{ model: Goal, as: 'goals' }],
   }).then(team => {
     gb = geckoboard(process.env.GECKOBOARD_API_KEY);


### PR DESCRIPTION
According to the Sequelize upgrade guide we are now using some deprecated methods on the Modal class. http://docs.sequelizejs.com/manual/upgrade-to-v5.html