### PR TITLE
Re-order stories inside a goal

### DIFF
--- a/client/src/components/goal/goal-styles.css
+++ b/client/src/components/goal/goal-styles.css
@@ -22,7 +22,7 @@
 }
 
 .stories_list {
-  padding-left: 32px;
+  padding-left: 22px;
 }
 
 .check_button, .edit_button {

--- a/client/src/components/goal/goal.js
+++ b/client/src/components/goal/goal.js
@@ -89,6 +89,7 @@ class Goal extends Component {
               return (
                 <LinkedStory
                   key={story.id}
+                  id={story.id}
                   story={story}
                   index={index + 1}
                   goalId={goal.id}

--- a/client/src/components/linked-story/linked-story-connector.js
+++ b/client/src/components/linked-story/linked-story-connector.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import * as actions from '../../redux/actions';
-import LinkedStory from './linked-story';
+import LinkedStoryDragWrapper from './linkedstory-drag-wrapper';
 
 const mapDispatchToProps = (dispatch, props) => ({
   onDelete: () =>
@@ -11,12 +11,13 @@ const mapDispatchToProps = (dispatch, props) => ({
         storyIds: [props.story.id],
       }),
     ),
+  onChangeOrder: update => dispatch(actions.updateStoryOrder(update)),
 });
 
 const LinkedStoryConnector = connect(
   null,
   mapDispatchToProps,
-)(LinkedStory);
+)(LinkedStoryDragWrapper);
 
 LinkedStoryConnector.propTypes = {
   story: PropTypes.shape({

--- a/client/src/components/linked-story/linked-story-connector.js
+++ b/client/src/components/linked-story/linked-story-connector.js
@@ -4,6 +4,7 @@ import * as actions from '../../redux/actions';
 import LinkedStoryDragWrapper from './linkedstory-drag-wrapper';
 
 const mapDispatchToProps = (dispatch, props) => ({
+  onSaveOrder: () => dispatch(actions.saveStoryOrders(props.goalId)),
   onDelete: () =>
     dispatch(
       actions.removeStoriesFromGoal({

--- a/client/src/components/linked-story/linked-story-styles.css
+++ b/client/src/components/linked-story/linked-story-styles.css
@@ -1,3 +1,7 @@
+.story_drag_container {
+  padding-left: 10px;
+}
+
 .story {
   color: #4a4a4a;
   position: relative;
@@ -45,6 +49,18 @@
 .name {
   flex: 1;
   line-height: 1.3;
+}
+
+.dragHandle {
+  cursor: -webkit-grab;
+}
+
+.isDragging {
+  opacity: 0;
+}
+
+.isDragging, .isDragging * {
+  cursor: -webkit-grabbing !important;
 }
 
 .id {

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -29,7 +29,8 @@ const getClassName = story =>
     ? `${styles.icon} ${styles.story_icon_completed}`
     : styles.icon;
 
-const LinkedStory = ({ story, index, onDelete }) => {
+const LinkedStory = props => {
+  const { story, index, connectDragSource, onDelete } = props;
   return (
     <div className={styles.story}>
       <span className={getClassName(story)}>
@@ -38,7 +39,9 @@ const LinkedStory = ({ story, index, onDelete }) => {
       <div className={styles.content}>
         <div className={styles.number}>{index}.</div>
         <div className={styles.name}>
-          {story.name}
+          {connectDragSource(
+            <span className={styles.dragHandle}>{story.name}</span>,
+          )}
           <span className={styles.after}>
             <a
               className={styles.id}
@@ -62,7 +65,10 @@ LinkedStory.propTypes = {
   story: PropTypes.shape({
     name: PropTypes.string,
   }),
+  goalId: PropTypes.number,
+  id: PropTypes.number,
   index: PropTypes.number,
+  connectDragSource: PropTypes.func,
   onDelete: PropTypes.func,
 };
 

--- a/client/src/components/linked-story/linkedstory-drag-wrapper.js
+++ b/client/src/components/linked-story/linkedstory-drag-wrapper.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { DragSource, DropTarget } from 'react-dnd';
+import LinkedStory from './linked-story';
+import { findDOMNode } from 'react-dom';
+import styles from './linked-story-styles.css';
+
+const LinkedStoryDragWrapper = props => {
+  const { connectDragPreview, connectDropTarget, isDragging, ...rest } = props;
+
+  return connectDropTarget(
+    connectDragPreview(
+      <div
+        className={
+          isDragging
+            ? `${styles.story_drag_container} ${styles.isDragging}`
+            : styles.story_drag_container
+        }
+      >
+        <LinkedStory {...rest} />
+      </div>,
+    ),
+  );
+};
+
+const linkedCardSource = {
+  beginDrag: props => props,
+
+  endDrag: (props, monitor) => {
+    if (monitor.didDrop()) {
+      //TODO: Save
+    }
+  },
+};
+
+const dropTargetSource = {
+  drop: props => ({
+    id: props.id,
+  }),
+  canDrop: (props, monitor) => {
+    // Don't allow dragging between different goals for now
+    return (
+      props.goalId === monitor.getItem().goalId &&
+      props.id !== monitor.getItem().id
+    );
+  },
+  hover: (props, monitor, component) => {
+    if (!monitor.canDrop()) {
+      return;
+    }
+
+    const dragIndex = monitor.getItem().index;
+    const hoverIndex = props.index;
+
+    // Determine rectangle on screen
+    const hoverBoundingRect = findDOMNode(component).getBoundingClientRect();
+
+    // Get vertical middle
+    const hoverMiddleY = (hoverBoundingRect.bottom - hoverBoundingRect.top) / 2;
+
+    // Determine mouse position
+    const clientOffset = monitor.getClientOffset();
+
+    // Get pixels to the top
+    const hoverClientY = clientOffset.y - hoverBoundingRect.top;
+
+    // Only perform the move when the mouse has crossed half of the items height
+    // When dragging downwards, only move when the cursor is below 50%
+    // When dragging upwards, only move when the cursor is above 50%
+    // Dragging downwards
+    if (dragIndex < hoverIndex && hoverClientY < hoverMiddleY) {
+      return;
+    }
+
+    // Dragging upwards
+    if (dragIndex > hoverIndex && hoverClientY > hoverMiddleY) {
+      return;
+    }
+
+    props.onChangeOrder({
+      id: monitor.getItem().id,
+      goalId: monitor.getItem().goalId,
+      from: dragIndex,
+      to: hoverIndex,
+    });
+  },
+};
+
+const collect = (connect, monitor) => ({
+  connectDragSource: connect.dragSource(),
+  connectDragPreview: connect.dragPreview(),
+  isDragging: monitor.isDragging(),
+});
+
+const dropTargetCollect = connect => ({
+  connectDropTarget: connect.dropTarget(),
+});
+
+export default DropTarget(
+  ['LINKED_STORY'],
+  dropTargetSource,
+  dropTargetCollect,
+)(
+  DragSource('LINKED_STORY', linkedCardSource, collect)(LinkedStoryDragWrapper),
+);

--- a/client/src/components/linked-story/linkedstory-drag-wrapper.js
+++ b/client/src/components/linked-story/linkedstory-drag-wrapper.js
@@ -24,11 +24,8 @@ const LinkedStoryDragWrapper = props => {
 
 const linkedCardSource = {
   beginDrag: props => props,
-
-  endDrag: (props, monitor) => {
-    if (monitor.didDrop()) {
-      //TODO: Save
-    }
+  endDrag: props => {
+    props.onSaveOrder();
   },
 };
 

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -164,6 +164,14 @@ export const removeStoriesFromGoal = createThunk(
   },
 );
 
+export const saveStoryOrders = createThunk(
+  'SAVE_STORY_ORDERS',
+  goalId => (_, getState) => {
+    let { cards } = getGoals(getState()).find(x => x.id === goalId);
+    return api.goals.update(goalId, { cards });
+  },
+);
+
 export const setTeam = createThunk('SET_TEAM', id => (dispatch, getState) => {
   const state = getState();
   const team = state.teams.entities.find(t => t.id === id);

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -42,6 +42,7 @@ const _completedInLastTwoWeeks = response => {
 export const setGoals = createAction('SET_GOALS');
 export const storiesReceived = createAction('STORIES_RECEIVED');
 export const updateGoalOrder = createAction('UPDATE_GOAL_ORDER');
+export const updateStoryOrder = createAction('UPDATE_STORY_ORDER');
 
 export const fetchTeams = createThunk('FETCH_TEAMS', () => () =>
   api.teams.get(),

--- a/client/src/redux/reducers/teams-reducer.js
+++ b/client/src/redux/reducers/teams-reducer.js
@@ -213,6 +213,32 @@ const teamsReducer = (state = initialState, action) => {
         }),
       };
 
+    case actions.updateStoryOrder.type:
+      const { id: cardIdToMove, goalId, to: toIndex } = payload;
+
+      return {
+        ...state,
+        entities: _updateCurrent(state, team => ({
+          ...team,
+          goals: team.goals.map(goal => {
+            if (goal.id !== goalId) {
+              return goal;
+            }
+
+            // Remove ID to re-order
+            let cards = goal.cards.filter(c => c !== cardIdToMove);
+
+            // Add ID back in correct place
+            cards.splice(toIndex - 1, 0, cardIdToMove);
+
+            return {
+              ...goal,
+              cards: cards,
+            };
+          }),
+        })),
+      };
+
     case socketActions.goals.updateOrders.type:
       return {
         ...state,


### PR DESCRIPTION
This allows re-ordering cards added to a goal by dragging them.

I've copied the functionality from the goal-drag-wrapper when it comes to deciding the position of the dragged story.

You can only drop the stories inside the the same goal.

![reodercards](https://user-images.githubusercontent.com/5096228/60092664-83b63100-973f-11e9-882e-ff045ed49c7d.gif)
