### PR TITLE
Show owner initials on linked stories

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -1,10 +1,12 @@
 import * as goals from './goals';
+import * as members from './members';
 import * as projects from './projects';
 import * as teams from './teams';
 import * as stories from './clubhouse/stories';
 
 export default {
   goals,
+  members,
   projects,
   teams,
   clubhouse: {

--- a/client/src/api/members.js
+++ b/client/src/api/members.js
@@ -1,0 +1,5 @@
+import { API, apiRequest, getJSON } from './utils';
+
+const getMembers = () => apiRequest(`${API}/members`).then(getJSON);
+
+export { getMembers as get };

--- a/client/src/components/app/app-connector.js
+++ b/client/src/components/app/app-connector.js
@@ -6,6 +6,7 @@ const mapDispatchToProps = dispatch => ({
   init: () => {
     dispatch(actions.fetchTeams());
     dispatch(actions.fetchProjects());
+    dispatch(actions.fetchMembers());
   },
   setTeam: team => dispatch(actions.setTeam(team)),
 });

--- a/client/src/components/goal/goal.js
+++ b/client/src/components/goal/goal.js
@@ -40,6 +40,7 @@ class Goal extends Component {
       goal,
       onDelete,
       onDeleteStories,
+      showStoryOwners,
       stories,
       loadingStories,
       createDragHandle,
@@ -93,6 +94,7 @@ class Goal extends Component {
                   story={story}
                   index={index + 1}
                   goalId={goal.id}
+                  showStoryOwners={showStoryOwners}
                 />
               );
             }
@@ -149,6 +151,7 @@ Goal.propTypes = {
   onDeleteStories: PropTypes.func,
   onChangeTitle: PropTypes.func,
   loadingStories: PropTypes.bool,
+  showStoryOwners: PropTypes.bool,
   stories: PropTypes.array,
   createDragHandle: PropTypes.func,
 };

--- a/client/src/components/goals-list/goals-list.js
+++ b/client/src/components/goals-list/goals-list.js
@@ -1,14 +1,46 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Goal from '../goal';
+import KeyListener from '../key-listener';
 
-const GoalsList = ({ goals }) => (
-  <div>
-    {goals.map(goal => (
-      <Goal key={goal.id} goal={goal} />
-    ))}
-  </div>
-);
+const isShowOwnersEnabled = () => {
+  return localStorage.getItem('show_story_owners') === 'true';
+};
+
+const storeShowOwnersState = showOwners => {
+  localStorage.setItem('show_story_owners', showOwners ? 'true' : 'false');
+};
+
+class GoalsList extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      showStoryOwners: isShowOwnersEnabled(),
+    };
+
+    this.toggleShowStoryOwners = this.toggleShowStoryOwners.bind(this);
+  }
+
+  toggleShowStoryOwners() {
+    const show = !this.state.showStoryOwners;
+    this.setState({ showStoryOwners: show });
+    storeShowOwnersState(show);
+  }
+
+  render() {
+    const { goals } = this.props;
+    const { showStoryOwners } = this.state;
+    return (
+      <div>
+        <KeyListener character="o" onKeyPress={this.toggleShowStoryOwners} />
+        {goals.map(goal => (
+          <Goal key={goal.id} goal={goal} showStoryOwners={showStoryOwners} />
+        ))}
+      </div>
+    );
+  }
+}
 
 GoalsList.propTypes = {
   goals: PropTypes.array,

--- a/client/src/components/linked-story/linked-story-connector.js
+++ b/client/src/components/linked-story/linked-story-connector.js
@@ -9,12 +9,14 @@ const mapStateToProps = (state, props) => {
     story: { owner_ids = [] },
   } = props;
 
-  const ownerNames = owner_ids.map(id => {
+  const ownerNames = owner_ids.reduce((owners, id) => {
     const member = members.byId[id];
-    if (!member) return null;
+    if (member) {
+      owners.push(member.profile.name);
+    }
 
-    return member.profile.name;
-  });
+    return owners;
+  }, []);
 
   return { ownerNames };
 };

--- a/client/src/components/linked-story/linked-story-connector.js
+++ b/client/src/components/linked-story/linked-story-connector.js
@@ -3,6 +3,22 @@ import PropTypes from 'prop-types';
 import * as actions from '../../redux/actions';
 import LinkedStoryDragWrapper from './linkedstory-drag-wrapper';
 
+const mapStateToProps = (state, props) => {
+  const { members } = state;
+  const {
+    story: { owner_ids = [] },
+  } = props;
+
+  const ownerNames = owner_ids.map(id => {
+    const member = members.byId[id];
+    if (!member) return null;
+
+    return member.profile.name;
+  });
+
+  return { ownerNames };
+};
+
 const mapDispatchToProps = (dispatch, props) => ({
   onSaveOrder: () => dispatch(actions.saveStoryOrders(props.goalId)),
   onDelete: () =>
@@ -16,7 +32,7 @@ const mapDispatchToProps = (dispatch, props) => ({
 });
 
 const LinkedStoryConnector = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(LinkedStoryDragWrapper);
 

--- a/client/src/components/linked-story/linked-story-styles.css
+++ b/client/src/components/linked-story/linked-story-styles.css
@@ -51,6 +51,29 @@
   line-height: 1.3;
 }
 
+.ownerList {
+  padding: 0 5px;
+}
+
+.owner {
+  margin: 0 0 0 5px;
+}
+
+.owner .initials {
+  box-sizing: border-box;
+  display: inline-block;
+  color: white;
+  font-size: 0.65rem;
+  font-weight: bold;
+  text-align: center;
+  padding-top: 3px;
+  background: #9B9B9B;
+  opacity: 0.5;
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+}
+
 .dragHandle {
   cursor: -webkit-grab;
 }

--- a/client/src/components/linked-story/linked-story-styles.css
+++ b/client/src/components/linked-story/linked-story-styles.css
@@ -43,12 +43,12 @@
 
 .number {
   margin-right: 8px;
-  line-height: 1.3;
+  line-height: 1.45;
 }
 
 .name {
   flex: 1;
-  line-height: 1.3;
+  line-height: 1.45;
 }
 
 .ownerList {

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -29,8 +29,27 @@ const getClassName = story =>
     ? `${styles.icon} ${styles.story_icon_completed}`
     : styles.icon;
 
+const getInitials = name => {
+  return name
+    .split(' ')
+    .map(n => n.slice(0, 1).toUpperCase())
+    .join('');
+};
+
+const renderOwners = ownerNames => {
+  return ownerNames.map((name, index) => {
+    return (
+      <span className={styles.owner} key={index}>
+        <span className={styles.initials}>{getInitials(name)}</span>
+      </span>
+    );
+  });
+};
+
 const LinkedStory = props => {
-  const { story, index, connectDragSource, onDelete } = props;
+  const { story, index, ownerNames, connectDragSource, onDelete } = props;
+  const doRenderOwners = !story.completed && !!ownerNames.length;
+
   return (
     <div className={styles.story}>
       <span className={getClassName(story)}>
@@ -41,6 +60,9 @@ const LinkedStory = props => {
         <div className={styles.name}>
           {connectDragSource(
             <span className={styles.dragHandle}>{story.name}</span>,
+          )}
+          {doRenderOwners && (
+            <span className={styles.ownerList}>{renderOwners(ownerNames)}</span>
           )}
           <span className={styles.after}>
             <a

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -47,8 +47,16 @@ const renderOwners = ownerNames => {
 };
 
 const LinkedStory = props => {
-  const { story, index, ownerNames, connectDragSource, onDelete } = props;
-  const doRenderOwners = !story.completed && !!ownerNames.length;
+  const {
+    story,
+    index,
+    ownerNames,
+    showStoryOwners,
+    connectDragSource,
+    onDelete,
+  } = props;
+  const doRenderOwners =
+    showStoryOwners && !story.completed && !!ownerNames.length;
 
   return (
     <div className={styles.story}>
@@ -91,6 +99,7 @@ LinkedStory.propTypes = {
   id: PropTypes.number,
   index: PropTypes.number,
   ownerNames: PropTypes.arrayOf(PropTypes.string),
+  showStoryOwners: PropTypes.bool,
   connectDragSource: PropTypes.func,
   onDelete: PropTypes.func,
 };

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -68,6 +68,7 @@ LinkedStory.propTypes = {
   goalId: PropTypes.number,
   id: PropTypes.number,
   index: PropTypes.number,
+  ownerNames: PropTypes.arrayOf(PropTypes.string),
   connectDragSource: PropTypes.func,
   onDelete: PropTypes.func,
 };

--- a/client/src/redux/actions.js
+++ b/client/src/redux/actions.js
@@ -52,6 +52,10 @@ export const fetchProjects = createThunk('FETCH_PROJECTS', () => () =>
   api.projects.get(),
 );
 
+export const fetchMembers = createThunk('FETCH_MEMBERS', () => () =>
+  api.members.get(),
+);
+
 export const addProject = createThunk(
   'ADD_PROJECT',
   project => (dispatch, getState) => {

--- a/client/src/redux/reducers/index.js
+++ b/client/src/redux/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
+import members from './members-reducer';
 import projects from './projects-reducer';
 import stories from './stories-reducer';
 import teams from './teams-reducer';
 
-export default combineReducers({ projects, stories, teams });
+export default combineReducers({ members, projects, stories, teams });

--- a/client/src/redux/reducers/members-reducer.js
+++ b/client/src/redux/reducers/members-reducer.js
@@ -5,7 +5,7 @@ const initialState = {
   byId: {},
 };
 
-const projectsReducer = (state = initialState, action) => {
+const membersReducer = (state = initialState, action) => {
   const { type, payload } = action;
 
   switch (type) {
@@ -33,4 +33,4 @@ const projectsReducer = (state = initialState, action) => {
   }
 };
 
-export default projectsReducer;
+export default membersReducer;

--- a/client/src/redux/reducers/members-reducer.js
+++ b/client/src/redux/reducers/members-reducer.js
@@ -1,0 +1,36 @@
+import * as actions from '../actions';
+
+const initialState = {
+  loading: true,
+  byId: {},
+};
+
+const projectsReducer = (state = initialState, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case actions.fetchMembers.start.type:
+      return {
+        ...state,
+        loading: true,
+        byId: {},
+      };
+
+    case actions.fetchMembers.end.type:
+      return {
+        ...state,
+        loading: false,
+        byId: payload.reduce((membersById, member) => {
+          return {
+            ...membersById,
+            [member.id]: member,
+          };
+        }, {}),
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default projectsReducer;

--- a/server/server/controllers/constants.js
+++ b/server/server/controllers/constants.js
@@ -1,0 +1,7 @@
+const API_URL = 'https://api.clubhouse.io/api/v2';
+const API_KEY = process.env.CLUBHOUSE_API_KEY;
+
+module.exports = {
+  API_URL,
+  API_KEY,
+};

--- a/server/server/controllers/helpers.js
+++ b/server/server/controllers/helpers.js
@@ -12,6 +12,7 @@ const whitelistStory = story => ({
   completed: story.completed,
   completed_at: story.completed_at,
   project_id: story.project_id,
+  owner_ids: story.owner_ids,
 });
 
 const whitelistMember = member => ({

--- a/server/server/controllers/helpers.js
+++ b/server/server/controllers/helpers.js
@@ -1,7 +1,5 @@
 const request = require('request-promise');
-
-const API = 'https://api.clubhouse.io/api/v2';
-const API_KEY = process.env.CLUBHOUSE_API_KEY;
+const { API_URL, API_KEY } = require('./constants');
 
 const whitelistStory = story => ({
   id: story.id,
@@ -19,13 +17,13 @@ const whitelistStory = story => ({
 const getStory = id =>
   request({
     qs: { token: API_KEY },
-    uri: `${API}/stories/${id}`,
+    uri: `${API_URL}/stories/${id}`,
   }).then(story => JSON.parse(story));
 
 const getWorkflowState = id =>
   request({
     qs: { token: API_KEY },
-    uri: `${API}/workflows`,
+    uri: `${API_URL}/workflows`,
   })
     .then(state => JSON.parse(state))
     .then(workflows => {

--- a/server/server/controllers/helpers.js
+++ b/server/server/controllers/helpers.js
@@ -14,6 +14,13 @@ const whitelistStory = story => ({
   project_id: story.project_id,
 });
 
+const whitelistMember = member => ({
+  id: member.id,
+  profile: {
+    name: member.profile.name,
+  },
+});
+
 const getStory = id =>
   request({
     qs: { token: API_KEY },
@@ -67,6 +74,7 @@ const isStoryDone = story => story.completed;
 
 module.exports = {
   whitelistStory,
+  whitelistMember,
   getStory,
   getWorkflowState,
   isStoryReadyOrDoing,

--- a/server/server/controllers/index.js
+++ b/server/server/controllers/index.js
@@ -1,4 +1,5 @@
 const goals = require('./goals');
+const members = require('./members');
 const projects = require('./projects');
 const stories = require('./stories');
 const teams = require('./teams');
@@ -6,6 +7,7 @@ const webhook = require('./webhook');
 
 module.exports = {
   goals,
+  members,
   projects,
   stories,
   webhook,

--- a/server/server/controllers/members.js
+++ b/server/server/controllers/members.js
@@ -1,0 +1,18 @@
+const request = require('request-promise');
+const { whitelistMember } = require('./helpers');
+const { API_URL, API_KEY } = require('./constants');
+
+const list = (req, res, next) =>
+  request({
+    uri: `${API_URL}/members`,
+    qs: { token: API_KEY },
+    json: true,
+  })
+    .then(members => {
+      return res.status(200).send(members.map(whitelistMember));
+    })
+    .catch(next);
+
+module.exports = {
+  list,
+};

--- a/server/server/controllers/projects.js
+++ b/server/server/controllers/projects.js
@@ -1,11 +1,9 @@
 const request = require('request-promise');
-
-const API = 'https://api.clubhouse.io/api/v2';
-const API_KEY = process.env.CLUBHOUSE_API_KEY;
+const { API_URL, API_KEY } = require('./constants');
 
 const list = (req, res, next) =>
   request({
-    uri: `${API}/projects`,
+    uri: `${API_URL}/projects`,
     qs: { token: API_KEY },
     json: true,
   })

--- a/server/server/controllers/stories.js
+++ b/server/server/controllers/stories.js
@@ -1,14 +1,12 @@
 const request = require('request-promise');
 const Goal = require('../models').goal;
 const { whitelistStory } = require('./helpers');
-
-const API = 'https://api.clubhouse.io/api/v2';
-const API_KEY = process.env.CLUBHOUSE_API_KEY;
+const { API_URL, API_KEY } = require('./constants');
 
 const _getTeamReadyColumn = teamId => {
   const options = {
     qs: { token: API_KEY },
-    uri: `${API}/teams/${teamId}`,
+    uri: `${API_URL}/teams/${teamId}`,
   };
 
   return request(options).then(response => {
@@ -34,7 +32,7 @@ const list = (req, res, next) => {
   };
 
   const options = {
-    uri: `${API}/search/stories`,
+    uri: `${API_URL}/search/stories`,
     qs,
     json: true,
   };
@@ -54,7 +52,7 @@ const create = (req, res, next) =>
     .then(column =>
       request({
         method: 'post',
-        uri: `${API}/stories`,
+        uri: `${API_URL}/stories`,
         qs: { token: API_KEY },
         body: {
           name: req.body.name,

--- a/server/server/routes/index.js
+++ b/server/server/routes/index.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const goalsController = require('../controllers').goals;
+const membersController = require('../controllers').members;
 const projectsController = require('../controllers').projects;
 const storiesController = require('../controllers').stories;
 const teamsController = require('../controllers').teams;
@@ -14,6 +15,8 @@ module.exports = app => {
 
   app.get('/api/teams', teamsController.list);
   app.put('/api/teams/:teamId', teamsController.update);
+
+  app.get('/api/members', membersController.list);
 
   app.get('/api/projects', projectsController.list);
 


### PR DESCRIPTION
When a story has one or more owners, show their initials on linked stories so that we can see who is working on what. When a story has been completed, don't render the initials anymore to avoid clutter in the UI.

The initials are hidden by default, you can toggle the initials on by pressing `o`. I added the `KeyListener` to the `goals-list` and from there pass the state down to the linked stories. Since wether or not the linked stories show the initials is more of a global state they all share, and not something you can toggle on each individual story, I didn't want to make them each have their own state and key listener.

Another way would be to keep the key listener in the `goals-list` (o move it somewhere higher up in the hierarchy) and store `showStoryOwners` in the redux state. I don't really have a preference, this was just a bit quicker to implement but I don't mind adding this to redux if you prefer.

And example of what it might look like. Hovering over story 6 to show the link to the story and delete button:
![image](https://user-images.githubusercontent.com/5096228/60169187-20d79f00-97fe-11e9-99e5-227f7103ac96.png)