### PR TITLE
Remove opacity from owner initials

### DIFF
--- a/client/src/components/linked-story/linked-story-styles.css
+++ b/client/src/components/linked-story/linked-story-styles.css
@@ -68,7 +68,6 @@
   text-align: center;
   padding-top: 3px;
   background: #9B9B9B;
-  opacity: 0.5;
   height: 20px;
   width: 20px;
   border-radius: 50%;


### PR DESCRIPTION
I've noticed it's difficult to read the initials on the TV in the meeting room. The grey background is too light for the white text. It had an opacity to match the story icons so it might not look as good now but I think it's more important we're able to read it :)

Let's see what this looks like on the TV and if it doesn't work I can amend it again.

![image](https://user-images.githubusercontent.com/5096228/62275452-e931c780-b439-11e9-87f0-95355cd44e31.png)
