### PR TITLE
Show story labels

### DIFF
--- a/client/src/components/goal/goal.js
+++ b/client/src/components/goal/goal.js
@@ -40,6 +40,7 @@ class Goal extends Component {
       goal,
       onDelete,
       onDeleteStories,
+      showStoryLabels,
       showStoryOwners,
       stories,
       loadingStories,
@@ -95,6 +96,7 @@ class Goal extends Component {
                   index={index + 1}
                   goalId={goal.id}
                   showStoryOwners={showStoryOwners}
+                  showStoryLabels={showStoryLabels}
                 />
               );
             }
@@ -151,6 +153,7 @@ Goal.propTypes = {
   onDeleteStories: PropTypes.func,
   onChangeTitle: PropTypes.func,
   loadingStories: PropTypes.bool,
+  showStoryLabels: PropTypes.bool,
   showStoryOwners: PropTypes.bool,
   stories: PropTypes.array,
   createDragHandle: PropTypes.func,

--- a/client/src/components/goals-list/goals-list.js
+++ b/client/src/components/goals-list/goals-list.js
@@ -11,15 +11,25 @@ const storeShowOwnersState = showOwners => {
   localStorage.setItem('show_story_owners', showOwners ? 'true' : 'false');
 };
 
+const isShowLabelsEnabled = () => {
+  return localStorage.getItem('show_story_labels') === 'true';
+};
+
+const storeShowLabelsState = showLabels => {
+  localStorage.setItem('show_story_labels', showLabels ? 'true' : 'false');
+};
+
 class GoalsList extends Component {
   constructor() {
     super();
 
     this.state = {
       showStoryOwners: isShowOwnersEnabled(),
+      showStoryLabels: isShowLabelsEnabled(),
     };
 
     this.toggleShowStoryOwners = this.toggleShowStoryOwners.bind(this);
+    this.toggleShowStoryLabels = this.toggleShowStoryLabels.bind(this);
   }
 
   toggleShowStoryOwners() {
@@ -28,14 +38,26 @@ class GoalsList extends Component {
     storeShowOwnersState(show);
   }
 
+  toggleShowStoryLabels() {
+    const show = !this.state.showStoryLabels;
+    this.setState({ showStoryLabels: show });
+    storeShowLabelsState(show);
+  }
+
   render() {
     const { goals } = this.props;
-    const { showStoryOwners } = this.state;
+    const { showStoryOwners, showStoryLabels } = this.state;
     return (
       <div>
         <KeyListener character="o" onKeyPress={this.toggleShowStoryOwners} />
+        <KeyListener character="l" onKeyPress={this.toggleShowStoryLabels} />
         {goals.map(goal => (
-          <Goal key={goal.id} goal={goal} showStoryOwners={showStoryOwners} />
+          <Goal
+            key={goal.id}
+            goal={goal}
+            showStoryOwners={showStoryOwners}
+            showStoryLabels={showStoryLabels}
+          />
         ))}
       </div>
     );

--- a/client/src/components/label-list/index.js
+++ b/client/src/components/label-list/index.js
@@ -1,0 +1,3 @@
+import LabelList from './label-list-component';
+
+export default LabelList;

--- a/client/src/components/label-list/label-list-component.js
+++ b/client/src/components/label-list/label-list-component.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './label-list-styles.css';
+
+const LabelList = ({ labels }) => {
+  return (
+    <ul className={styles.label_list}>
+      {labels.map(label => (
+        <li key={label.name}>
+          <span
+            className={styles.label_dot}
+            style={label.color && { background: label.color }}
+          />
+          {label.name}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+LabelList.defaultProps = {
+  labels: [],
+};
+
+LabelList.propTypes = {
+  labels: PropTypes.arrayOf(
+    PropTypes.shape({
+      color: PropTypes.string,
+      name: PropTypes.string.isRequired,
+    }),
+  ),
+};
+
+export default LabelList;

--- a/client/src/components/label-list/label-list-styles.css
+++ b/client/src/components/label-list/label-list-styles.css
@@ -1,0 +1,28 @@
+.label_list {
+  color: #4A4A4A;
+  list-style: none;
+  margin: 0 0 0 5px;
+  padding: 0;
+  display: inline-block;
+}
+
+.label_list li {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 0 rgba(0,0,0,.08);
+  margin: 0 0 0 5px;
+  padding: 3px 6px;
+  border-radius: 5px;
+  font-size: 11px;
+  display: inline-block;
+  vertical-align: bottom;
+}
+
+.label_dot {
+  background: #f5e6ad;
+  display: inline-block;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 4px;
+  width: 10px;
+  height: 10px;
+}

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as icons from '@fortawesome/free-solid-svg-icons';
+import LabelList from '../label-list';
 import styles from './linked-story-styles.css';
 
 const getIcon = story => {
@@ -69,6 +70,7 @@ const LinkedStory = props => {
           {connectDragSource(
             <span className={styles.dragHandle}>{story.name}</span>,
           )}
+          <LabelList labels={story.labels} />
           {doRenderOwners && (
             <span className={styles.ownerList}>{renderOwners(ownerNames)}</span>
           )}
@@ -94,6 +96,12 @@ const LinkedStory = props => {
 LinkedStory.propTypes = {
   story: PropTypes.shape({
     name: PropTypes.string,
+    labels: PropTypes.arrayOf(
+      PropTypes.shape({
+        color: PropTypes.string,
+        name: PropTypes.string.isRequired,
+      }),
+    ),
   }),
   goalId: PropTypes.number,
   id: PropTypes.number,

--- a/client/src/components/linked-story/linked-story.js
+++ b/client/src/components/linked-story/linked-story.js
@@ -52,6 +52,7 @@ const LinkedStory = props => {
     story,
     index,
     ownerNames,
+    showStoryLabels,
     showStoryOwners,
     connectDragSource,
     onDelete,
@@ -70,7 +71,7 @@ const LinkedStory = props => {
           {connectDragSource(
             <span className={styles.dragHandle}>{story.name}</span>,
           )}
-          <LabelList labels={story.labels} />
+          {showStoryLabels && <LabelList labels={story.labels} />}
           {doRenderOwners && (
             <span className={styles.ownerList}>{renderOwners(ownerNames)}</span>
           )}
@@ -107,6 +108,7 @@ LinkedStory.propTypes = {
   id: PropTypes.number,
   index: PropTypes.number,
   ownerNames: PropTypes.arrayOf(PropTypes.string),
+  showStoryLabels: PropTypes.bool,
   showStoryOwners: PropTypes.bool,
   connectDragSource: PropTypes.func,
   onDelete: PropTypes.func,

--- a/server/server/controllers/helpers.js
+++ b/server/server/controllers/helpers.js
@@ -13,6 +13,12 @@ const whitelistStory = story => ({
   completed_at: story.completed_at,
   project_id: story.project_id,
   owner_ids: story.owner_ids,
+  labels: story.labels.map(whitelistLabel),
+});
+
+const whitelistLabel = label => ({
+  color: label.color,
+  name: label.name,
 });
 
 const whitelistMember = member => ({


### PR DESCRIPTION
In Taco we use labels on the stories to easily tag backend and frontend work. It would help us in planning and standup if these labels showed up in keeper.

I've added them as hidden by default, they can be toggled on by pressing `L` on the keyboard.

If you add a custom colour to a label in clubhouse, it comes through in the API. If you don't set a colour, the colour is `null` from the API so I've defaulted to mark the labels with the same yellow colour that clubhouse uses by default. The styling with the border and box shadow are copied from clubhouse as well to make it easier to understand that they are labels, but any feedback on the styling is welcome!

<img width="789" alt="Screenshot 2019-10-17 at 15 10 33" src="https://user-images.githubusercontent.com/5096228/67023907-73b1cb00-f0fb-11e9-8965-7c4c090f2f8d.png">
