### PR TITLE
Try using SSL to connect to DB in production

### DIFF
--- a/server/server/config/config.json
+++ b/server/server/config/config.json
@@ -8,6 +8,10 @@
     "dialect": "postgres"
   },
   "production": {
-    "use_env_variable": "DATABASE_URL"
+    "use_env_variable": "DATABASE_URL",
+    "ssl": true,
+    "dialectOptions": {
+      "ssl": true
+    }
   }
 }


### PR DESCRIPTION
I can see this error in the Heroku logs

![image](https://user-images.githubusercontent.com/6588325/127497431-52bcc498-5912-4a91-96e1-e20784ba2370.png)

I found this stack overflow post that mentions the same error and the answer suggests that I should try connecting to Postgres over SSL

https://stackoverflow.com/questions/25000183/node-js-postgresql-error-no-pg-hba-conf-entry-for-host